### PR TITLE
Drop PhpSpec 5 for PhpSpec 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@
 
 ## Compatibility
 
-| PHPStan version | PhpSpec extension version |
-| --------------- | ---------------------- |
-| 0.11.6          | 0.2.x                  |
-| 0.10.7          | 0.1.x                  |
+| PHPStan version | PhpSpec version | PhpSpec extension version |
+| --------------- | --------------- | ------------------------- |
+| ^0.11.6         | ^6.0            | 0.3.x                     |
+| ^0.11.6         | ^5.1            | 0.2.x                     |
+| ^0.10.7         | ^5.1            | 0.1.x                     |
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "phpstan/phpstan": "^0.11.6",
         "nikic/php-parser": "^4.1",
-        "phpspec/phpspec": "^5.1"
+        "phpspec/phpspec": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,73 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63bd1533ccf5161239015bbf2bea677b",
+    "content-hash": "0575c4290fa6934a33982f8f5e5a97ad",
     "packages": [
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.2 - 1.8.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-23T11:49:37+00:00"
+        },
         {
             "name": "composer/xdebug-handler",
             "version": "1.3.2",
@@ -732,56 +797,6 @@
             "time": "2019-02-16T20:54:15+00:00"
         },
         {
-            "name": "ocramius/package-versions",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
-                "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-02-21T12:16:21+00:00"
-        },
-        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -973,22 +988,22 @@
         },
         {
             "name": "phpspec/phpspec",
-            "version": "5.1.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/phpspec.git",
-                "reference": "4badea737c34a6c8e2921fca0f6a1cbe4f724f2f"
+                "reference": "d78e90427386063729afe989f9038da0c3212dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/4badea737c34a6c8e2921fca0f6a1cbe4f724f2f",
-                "reference": "4badea737c34a6c8e2921fca0f6a1cbe4f724f2f",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/d78e90427386063729afe989f9038da0c3212dff",
+                "reference": "d78e90427386063729afe989f9038da0c3212dff",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "ext-tokenizer": "*",
-                "php": "^7.1, <7.4",
+                "php": "^7.2, <7.4",
                 "phpspec/php-diff": "^1.0.0",
                 "phpspec/prophecy": "^1.7",
                 "sebastian/exporter": "^1.0 || ^2.0 || ^3.0",
@@ -997,6 +1012,9 @@
                 "symfony/finder": "^3.4 || ^4.0",
                 "symfony/process": "^3.4 || ^4.0",
                 "symfony/yaml": "^3.4 || ^4.0"
+            },
+            "conflict": {
+                "sebastian/comparator": "<1.2.4"
             },
             "require-dev": {
                 "behat/behat": "^3.3",
@@ -1012,7 +1030,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -1039,7 +1057,7 @@
                     "homepage": "https://ciaranmcnulty.com/"
                 }
             ],
-            "description": "Specification-oriented BDD framework for PHP 5.6+",
+            "description": "Specification-oriented BDD framework for PHP 7.1+",
             "homepage": "http://phpspec.net/",
             "keywords": [
                 "BDD",
@@ -1050,7 +1068,7 @@
                 "testing",
                 "tests"
             ],
-            "time": "2018-10-29T08:12:52+00:00"
+            "time": "2019-10-02T09:56:42+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3690,5 +3708,6 @@
     "platform": {
         "php": "^7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
+++ b/spec/PhpSpec/CodeGenerator/Generator/SpecificationGeneratorSpec.php
@@ -56,6 +56,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
             '%filepath%' => '/project/spec/Acme/AppSpec.php',
             '%name%' => 'AppSpec',
             '%namespace%' => 'spec\Acme',
+            '%imports%' => "use Acme\App;\nuse PhpSpec\ObjectBehavior;",
             '%subject%' => 'Acme\App',
             '%subject_class%' => 'App'
         ];
@@ -86,6 +87,7 @@ class SpecificationGeneratorSpec extends ObjectBehavior
             '%filepath%' => '/project/spec/Acme/AppSpec.php',
             '%name%' => 'AppSpec',
             '%namespace%' => 'spec\Acme',
+            '%imports%' => "use Acme\App;\nuse PhpSpec\ObjectBehavior;",
             '%subject%' => 'Acme\App',
             '%subject_class%' => 'App'
         ];

--- a/spec/PhpSpec/Formatter/Presenter/Differ/ArrayEngineSpec.php
+++ b/spec/PhpSpec/Formatter/Presenter/Differ/ArrayEngineSpec.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace spec\PhpSpec\Formatter\Presenter\Differ;
 
 use PhpSpec\ObjectBehavior;
+use SebastianBergmann\Exporter\Exporter;
 
 class ArrayEngineSpec extends ObjectBehavior
 {
+    public function let(Exporter $exporter)
+    {
+        $this->beConstructedWith($exporter);
+    }
+
     public function it_is_a_diff_engine()
     {
         $this->shouldBeAnInstanceOf('PhpSpec\Formatter\Presenter\Differ\DifferEngine');


### PR DESCRIPTION
Hi, my team and me would like to setup PHPStan with PHPSpec with this extension, but we can't since : 
- we use PHPSpec 6
- we use PHPStan 12

This PR replace requirement on PhpSpec 5 for PhpSpec 6. This should go for a v0.3 I think.

I've tried to add support for both versions in order to prevent a breaking change, but there is too much things to do and I don't wanted to do that in this PR: 
- update Travis to run composer with `--prefer-lowest`
- remove `composer.lock`, a library should not commit a `composer.lock` since it's not used by composer when the library is being installed on a project, and it's counter-productive if you ran `composer update` or `composer update --prefer-lowest` locally
- I've tried to delete the `composer.lock` and ran `composer update`, but I had issues with PHPStan with abstract methods that were implemented in ^0.11.9 (see https://github.com/mglaman/drupal-check/issues/93)

By using a `composer.lock` and not testing lowest/highest packages versions on Travis, we are stuck with PHPStan `0.11.6`. Even if we require `^0.11.6`, version `0.11.9` or more match this version constraint and so it breaks. 
People which use this extension are condemned to use PHPStan 0.11.6, not more.

However I can help you for this, I've planned to open a PR for PHPStan 0.12 (but after this PR).

What do you think?

Thanks!